### PR TITLE
Feature/file management/remove image files when destroy

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,4 +1,11 @@
 class Photo < ApplicationRecord
   belongs_to :sale, optional: true
   mount_uploader :image, ImageUploader
+  before_destroy :remove_image
+
+  def remove_image
+    image.remove!
+  rescue Exception => e
+    logger.error(e.message)
+  end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -13,7 +13,11 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    if Rails.env.test?
+      "uploads_#{Rails.env}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    else
+      "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    end
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,11 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+
+  # テスト終了時にテスト時に保存された画像ファイル群を削除
+  config.after(:all) do
+    if Rails.env.test?
+      FileUtils.rm_rf(Dir["#{Rails.root}/public/uploads_#{Rails.env}/"])
+    end
+  end
 end


### PR DESCRIPTION
# What
不要になった画像ファイルの削除

# Why
DBからphotoのデータが削除されたとき、同時に画像ファイルを削除することで、アップロード先に余分なファイルが蓄えられるのを防ぐため。
また、テスト時に生成される画像ファイルをテスト終了時に削除する。