### PR TITLE
商品の取引完了ボタンの実装

### DIFF
--- a/app/controllers/sales_controller.rb
+++ b/app/controllers/sales_controller.rb
@@ -45,6 +45,17 @@ class SalesController < ApplicationController
     end
   end
 
+  def shipped
+    @sale = Sale.find(params[:sale_id]) 
+    if @sale.seller_id == current_user.id && @sale.status == "shipping"
+      @sale.update(status:"soldout")
+      redirect_to root_path, notice: '出品完了を受理しました'
+    else
+      flash.now[:alert] = 'データの更新に失敗しました'
+      render "show"
+    end
+  end
+
   private 
     def sale_params
       params.require(:sale).permit(:name, :detail, :condition_id, :delivery_payer_id, :prefecture_id, :prep_days_id, :price, category_ids: [], photos_attributes: [:image]).merge(seller_id: current_user.id)

--- a/app/views/sales/show.html.haml
+++ b/app/views/sales/show.html.haml
@@ -68,9 +68,9 @@
           = link_to('サインインする', new_user_session_path, class: 'edit-btn')
     - when "shipping"
       - if user_signed_in? && current_user.id == @sale.seller_id
-        .sales-show__contents__inactive
-          .edit-btn 
-            商品を発送してください
+        .sales-show__contents__edit
+          =link_to sale_shipped_path(@sale.id), method: :post, class: "edit-btn" do
+            商品の発送をしたので、取引を完了する
       - elsif user_signed_in? && current_user.id == @sale.order.buyer_id
         商品を発送中です。商品を確認したら速やかに下のボタンを押してください。
         .sales-show__contents__inactive
@@ -84,7 +84,7 @@
       - if user_signed_in? && current_user.id == @sale.seller_id
         .sales-show__contents__inactive
           .edit-btn 
-            購入者が商品を確認しました
+            取引は完了しました
       - elsif user_signed_in? && current_user.id == @sale.order.buyer_id
         .sales-show__contents__inactive
           .edit-btn 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   # 商品関連
   root to: 'sales#index'
   resources :sales, only: [:new, :show, :create, :edit, :destroy] do
+    post "shipped", to: "shipped"
     resources :orders, only: [:new, :create]
   end
   resources :category, controller: :categories, only: [:index, :show]


### PR DESCRIPTION
# What
商品の取引完了ボタンの実装

# Why
販売者が商品の発送を完了し、取引が完了したことをDBに保存するため。