### PR TITLE
ニックネーム登録ができないエラーの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
     end
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:firstname, :lastname])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:firstname, :lastname, :nickname])
     end
 
   protected

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,8 +21,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
       pass = Devise.friendly_token
       params[:user][:password] = pass
       params[:user][:password_confirmation] = pass
+      super
     end
-    super
+    
     
   end
 


### PR DESCRIPTION
# What
新規登録画面において、ニックネームの登録ができないエラーを修正した

# Why
新規登録において、ニックネームの登録は必須のため