### PR TITLE
ログアウトボタンのリンク適応範囲を修正

### DIFF
--- a/app/assets/stylesheets/mypages.scss
+++ b/app/assets/stylesheets/mypages.scss
@@ -217,8 +217,9 @@
             width: 340px;
             margin: 0 auto;
             cursor: pointer;
-            a {
+            .log-out-link{
               color: white;
+              display: block;
             }
           }
         }


### PR DESCRIPTION
#what
ボタンがクリックされたらログアウトできるようした

#why 
ログアウトの文字をクリックしないとログアウトができず使いにくかったから。

[![Image from Gyazo](https://i.gyazo.com/3946aa16e671dbdf23313f073e1fed86.gif)](https://gyazo.com/3946aa16e671dbdf23313f073e1fed86)